### PR TITLE
Edited merge_vulnerabilities.js

### DIFF
--- a/merge_vulnerabilities.js
+++ b/merge_vulnerabilities.js
@@ -12,7 +12,7 @@ var mergeVulnerabilities = function (titleRegex, minCVSS, maxCVSS, hostsRegex, n
     // hostsRegex - host IPs to include in filter
     // newTitle - title of the new vulnerability
     // newCVSS - new CVSS score, or choose "max" to pick the highest CVSS score of that group
-    // update - The update parameter determines whether it's a "dry run" with output, or an actual merge.
+    // update - The update parameter determines whether it's a "dry run" with output, or an actual merge. update = true will delete old entries
     //
     // Created by: Alex Lauerman and Tom Steele
     // Requires client-side updates: false
@@ -60,7 +60,7 @@ var mergeVulnerabilities = function (titleRegex, minCVSS, maxCVSS, hostsRegex, n
 
     console.log("Total found: " + vulnerabilities.length + " Highest CVSS: " + highestCVSS);
 
-    if (!update) {
+    if (update) {
         if (newCVSS == "max") {
             newCVSS = highestCVSS;
         }


### PR DESCRIPTION
The update parameter was used in a counter intuitive way. Previously, update = false would cause the deletion of old entries. Now, update = false is a dry-run.

Edited function use comment, regarding update value, to be more descriptive